### PR TITLE
Fix strat split index mismatch

### DIFF
--- a/autoxai4omics/utils/ml/data_split.py
+++ b/autoxai4omics/utils/ml/data_split.py
@@ -145,7 +145,19 @@ def strat_split(
     if not isinstance(group_name, str):
         raise TypeError(f"group_name must be a str, provided: {type(group_name)}")
 
+    if isinstance(x, DataFrame) and isinstance(y, ndarray):
+        if y.ndim == 1:
+            y = pd.Series(y, index=x.index)
+        else: 
+            y = pd.DataFrame(y, index=x.index)
+
     metadata = pd.read_csv(meta_file, index_col=0)
+
+    common_indices = x.index.intersection(y.index).intersection(metadata.index)
+
+    x = x.loc[common_indices]
+    y = y.loc[common_indices] 
+    metadata = metadata.loc[common_indices]
 
     if group_name not in metadata.columns:
         raise ValueError(

--- a/autoxai4omics/utils/ml/data_split.py
+++ b/autoxai4omics/utils/ml/data_split.py
@@ -39,7 +39,7 @@ def split_data(x, y, config_dict):
         x_train, x_test, y_train, y_test = strat_split(
             x,
             y,
-            config_dict["data"]["metadata_file"],
+            str(config_dict["data"]["metadata_file"]),
             config_dict["ml"]["groups"],
             config_dict["ml"]["test_size"],
             config_dict["ml"]["seed_num"],


### PR DESCRIPTION
Addresses an issue where `x`, `y`, and `metadata` could have misaligned indices in `strat_split`. Previously, `metadata` was reloaded independently, leading to sample mismatches in case of preprocessing.

Now, `y` is converted to a DataFrame/Series with `x`'s index if necessary, and all three (x, y, metadata) are strictly aligned using their common intersection of indices. This also guarantees correct data partitioning.